### PR TITLE
[Feat] Todo 상세 조회 및 수정 구현

### DIFF
--- a/app/todos/detail/page.tsx
+++ b/app/todos/detail/page.tsx
@@ -66,7 +66,16 @@ export default function GetAllList() {
             </Accordion>
           </div>
 
-          <TodoDetailModal id={selectedTodoId} open={detailOpen} onOpenChange={setDetailOpen} />
+          <TodoDetailModal
+            id={selectedTodoId}
+            open={detailOpen}
+            onOpenChange={(open) => {
+              setDetailOpen(open);
+              if (!open) {
+                setSelectedTodoId(null);
+              }
+            }}
+          />
         </>
       )}
     </div>

--- a/app/todos/detail/page.tsx
+++ b/app/todos/detail/page.tsx
@@ -10,7 +10,7 @@ import { Button } from '@/components/ui/button';
 import { TodoDetailModal } from '@/components/todos/detailModal';
 import { useState } from 'react';
 
-export default function GetAllList() {
+export default function GetDetailTodo() {
   const { data, isLoading, error } = useGetAllList();
   const { mutate: patchCompleted } = usePatchCompletedList();
 

--- a/app/todos/detail/page.tsx
+++ b/app/todos/detail/page.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Eye, LoaderCircle } from 'lucide-react';
+import { TodoProps } from '@/interfaces/todos.interface';
+import { useGetAllList } from '@/queries/todos/queries';
+import { usePatchCompletedList } from '@/queries/todos/mutation';
+import { Button } from '@/components/ui/button';
+import { TodoDetailModal } from '@/components/todos/detailModal';
+import { useState } from 'react';
+
+export default function GetAllList() {
+  const { data, isLoading, error } = useGetAllList();
+  const { mutate: patchCompleted } = usePatchCompletedList();
+
+  const [detailOpen, setDetailOpen] = useState(false);
+  const [selectedTodoId, setSelectedTodoId] = useState<number | null>(null);
+
+  const openDetail = (id: number) => {
+    setSelectedTodoId(id);
+    setDetailOpen(true);
+  };
+
+  return (
+    <div>
+      <h1>투두 리스트</h1>
+      {isLoading ? (
+        <div className="flex justify-center items-center h-screen">
+          <LoaderCircle className="mr-2 h-4 w-4 animate-spin" />
+          로딩 중...
+        </div>
+      ) : error ? (
+        <div>에러가 발생했습니다: {error.message}</div>
+      ) : (
+        <>
+          <div className="m-10 p-3 border border-solid">
+            <Accordion type="single" collapsible className="w-full">
+              {data?.map((todo: TodoProps) => (
+                <AccordionItem value={todo.id.toString()} key={todo.id}>
+                  <div className="flex">
+                    <Checkbox
+                      checked={todo.completed}
+                      className="flex mt-5 mr-5"
+                      onCheckedChange={() => patchCompleted({ id: todo.id, completed: !todo.completed })}
+                    />
+                    <div className="flex-1">
+                      <AccordionTrigger>
+                        <h3>{todo.title}</h3>
+                      </AccordionTrigger>
+                      <AccordionContent>{todo.description}</AccordionContent>
+                    </div>
+                    <Button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        openDetail(todo.id);
+                      }}
+                      variant="outline"
+                      size="icon"
+                    >
+                      <Eye className="h-4 w-4 text-blue-400" />
+                    </Button>
+                  </div>
+                </AccordionItem>
+              ))}
+            </Accordion>
+          </div>
+
+          <TodoDetailModal id={selectedTodoId} open={detailOpen} onOpenChange={setDetailOpen} />
+        </>
+      )}
+    </div>
+  );
+}

--- a/components/todos/detailModal.tsx
+++ b/components/todos/detailModal.tsx
@@ -10,6 +10,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import { useGetTodoDetail } from '@/queries/todos/queries';
 
 interface TodoDetailModalProps {
   id: number | null;
@@ -18,11 +19,12 @@ interface TodoDetailModalProps {
 }
 
 export function TodoDetailModal({ id, open, onOpenChange }: TodoDetailModalProps) {
+  const { data, isLoading, error } = useGetTodoDetail(open ? id : null);
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-[500px]">
         <DialogHeader>
-          <DialogTitle>Todo Title</DialogTitle>
+          <DialogTitle>Todo.title</DialogTitle>
           <DialogDescription>Todo Descriptioin</DialogDescription>
         </DialogHeader>
         <DialogFooter>

--- a/components/todos/detailModal.tsx
+++ b/components/todos/detailModal.tsx
@@ -11,6 +11,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { useGetTodoDetail } from '@/queries/todos/queries';
+import { LoaderCircle } from 'lucide-react';
 
 interface TodoDetailModalProps {
   id: number | null;
@@ -22,15 +23,27 @@ export function TodoDetailModal({ id, open, onOpenChange }: TodoDetailModalProps
   const { data, isLoading, error } = useGetTodoDetail(open ? id : null);
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[500px]">
+      <DialogContent className="sm:max-w-[425px]">
         <DialogHeader>
-          <DialogTitle>Todo.title</DialogTitle>
-          <DialogDescription>Todo Descriptioin</DialogDescription>
+          {isLoading ? (
+            <>
+              <LoaderCircle className="mr-2 h-4 w-4 animate-spin" />
+              로딩 중...
+            </>
+          ) : error ? (
+            <>
+              <DialogTitle>에러 발생</DialogTitle>
+              <DialogDescription>Todo 정보를 불러오는 데 실패했습니다.</DialogDescription>
+            </>
+          ) : (
+            <>
+              <DialogTitle>{data?.title}</DialogTitle>
+              <DialogDescription>{data?.description}</DialogDescription>
+            </>
+          )}
         </DialogHeader>
         <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)}>
-            닫기
-          </Button>
+          <Button onClick={() => onOpenChange(false)}>닫기</Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/components/todos/detailModal.tsx
+++ b/components/todos/detailModal.tsx
@@ -8,6 +8,7 @@ import { useEffect, useState } from 'react';
 import { Skeleton } from '../ui/skeleton';
 import { Input } from '../ui/input';
 import { Textarea } from '../ui/textarea';
+import { useUpdateTodo } from '@/queries/todos/mutation';
 
 interface TodoDetailModalProps {
   id: number | null;
@@ -19,6 +20,9 @@ export function TodoDetailModal({ id, open, onOpenChange }: TodoDetailModalProps
   const { data, isLoading, error } = useGetTodoDetail(open ? id : null);
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
+  const { mutate, isPending } = useUpdateTodo();
+
+  const hasError = Boolean(error);
 
   useEffect(() => {
     if (data) {
@@ -27,10 +31,24 @@ export function TodoDetailModal({ id, open, onOpenChange }: TodoDetailModalProps
     }
   }, [data]);
 
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (id) {
+      mutate(
+        { id, title, description },
+        {
+          onSuccess: () => {
+            onOpenChange(false);
+          },
+        },
+      );
+    }
+  };
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-[425px]">
-        <form>
+        <form onSubmit={handleSubmit}>
           <DialogHeader>
             <DialogTitle>Todo 수정</DialogTitle>
           </DialogHeader>
@@ -65,6 +83,15 @@ export function TodoDetailModal({ id, open, onOpenChange }: TodoDetailModalProps
               </div>
             </div>
           )}
+
+          <DialogFooter className="gap-2 mt-4">
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={isPending}>
+              취소
+            </Button>
+            <Button type="submit" disabled={isLoading || hasError || isPending}>
+              {isPending ? '저장 중...' : '저장'}
+            </Button>
+          </DialogFooter>
         </form>
       </DialogContent>
     </Dialog>

--- a/components/todos/detailModal.tsx
+++ b/components/todos/detailModal.tsx
@@ -2,16 +2,12 @@
 'use client';
 
 import { Button } from '@/components/ui/button';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { useGetTodoDetail } from '@/queries/todos/queries';
-import { LoaderCircle } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { Skeleton } from '../ui/skeleton';
+import { Input } from '../ui/input';
+import { Textarea } from '../ui/textarea';
 
 interface TodoDetailModalProps {
   id: number | null;
@@ -21,30 +17,55 @@ interface TodoDetailModalProps {
 
 export function TodoDetailModal({ id, open, onOpenChange }: TodoDetailModalProps) {
   const { data, isLoading, error } = useGetTodoDetail(open ? id : null);
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+
+  useEffect(() => {
+    if (data) {
+      setTitle(data.title || '');
+      setDescription(data.description || '');
+    }
+  }, [data]);
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-[425px]">
-        <DialogHeader>
+        <form>
+          <DialogHeader>
+            <DialogTitle>Todo 수정</DialogTitle>
+          </DialogHeader>
+
           {isLoading ? (
             <>
-              <LoaderCircle className="mr-2 h-4 w-4 animate-spin" />
-              로딩 중...
+              <Skeleton className="h-10 w-full mt-4 mb-4" />
+              <Skeleton className="h-24 w-full mb-4" />
             </>
           ) : error ? (
-            <>
-              <DialogTitle>에러 발생</DialogTitle>
-              <DialogDescription>Todo 정보를 불러오는 데 실패했습니다.</DialogDescription>
-            </>
+            <div className="text-red-500 py-4">데이터를 불러오는 데 실패했습니다.</div>
           ) : (
-            <>
-              <DialogTitle>{data?.title}</DialogTitle>
-              <DialogDescription>{data?.description}</DialogDescription>
-            </>
+            <div className="py-4 space-y-4">
+              <div className="space-y-2">
+                <label htmlFor="title" className="text-sm font-medium">
+                  제목
+                </label>
+                <Input id="title" value={title} onChange={(e) => setTitle(e.target.value)} placeholder="Todo 제목" />
+              </div>
+
+              <div className="space-y-2">
+                <label htmlFor="description" className="text-sm font-medium">
+                  설명
+                </label>
+                <Textarea
+                  id="description"
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  placeholder="Todo 설명"
+                  rows={4}
+                />
+              </div>
+            </div>
           )}
-        </DialogHeader>
-        <DialogFooter>
-          <Button onClick={() => onOpenChange(false)}>닫기</Button>
-        </DialogFooter>
+        </form>
       </DialogContent>
     </Dialog>
   );

--- a/components/todos/detailModal.tsx
+++ b/components/todos/detailModal.tsx
@@ -19,6 +19,7 @@ interface TodoDetailModalProps {
 export function TodoDetailModal({ id, open, onOpenChange }: TodoDetailModalProps) {
   const { data, isLoading, error } = useGetTodoDetail(open ? id : null);
   const [title, setTitle] = useState('');
+  const [titleError, setTitleError] = useState('');
   const [description, setDescription] = useState('');
   const { mutate, isPending } = useUpdateTodo();
 
@@ -28,8 +29,20 @@ export function TodoDetailModal({ id, open, onOpenChange }: TodoDetailModalProps
     if (data) {
       setTitle(data.title || '');
       setDescription(data.description || '');
+      setTitleError('');
     }
   }, [data]);
+
+  const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newTitle = e.target.value;
+    setTitle(newTitle);
+
+    if (!newTitle.trim()) {
+      setTitleError('제목을 입력해주세요');
+    } else {
+      setTitleError('');
+    }
+  };
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -66,7 +79,7 @@ export function TodoDetailModal({ id, open, onOpenChange }: TodoDetailModalProps
                 <label htmlFor="title" className="text-sm font-medium">
                   제목
                 </label>
-                <Input id="title" value={title} onChange={(e) => setTitle(e.target.value)} placeholder="Todo 제목" />
+                <Input id="title" value={title} onChange={handleTitleChange} placeholder="Todo 제목" />
               </div>
 
               <div className="space-y-2">

--- a/components/todos/detailModal.tsx
+++ b/components/todos/detailModal.tsx
@@ -1,0 +1,36 @@
+// components/TodoDetailModal.tsx
+'use client';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+
+interface TodoDetailModalProps {
+  id: number | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function TodoDetailModal({ id, open, onOpenChange }: TodoDetailModalProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[500px]">
+        <DialogHeader>
+          <DialogTitle>Todo Title</DialogTitle>
+          <DialogDescription>Todo Descriptioin</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            닫기
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/queries/todos/mutation.ts
+++ b/queries/todos/mutation.ts
@@ -1,36 +1,16 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-// 리스트 완료 여부 수정
-const patchCompletedList = async (id: number, completed: boolean) => {
+const updateTodoItem = async <T extends object>(id: number, updateData: T) => {
+  if ('title' in updateData && (updateData as any).title.trim() === '') {
+    throw new Error('제목은 필수 입력 항목입니다.');
+  }
+
   const response = await fetch(`/api/todos/${id}`, {
     method: 'PATCH',
     headers: {
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({ completed }),
-  });
-  const data = await response.json();
-  return data;
-};
-
-export const usePatchCompletedList = () => {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: ({ id, completed }: { id: number; completed: boolean }) => patchCompletedList(id, completed),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['todos'] });
-    },
-  });
-};
-
-const updateTodo = async (id: number, title: string, description: string) => {
-  const response = await fetch(`/api/todos/${id}`, {
-    method: 'PATCH',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ title, description }),
+    body: JSON.stringify(updateData),
   });
 
   if (!response.ok) {
@@ -40,12 +20,23 @@ const updateTodo = async (id: number, title: string, description: string) => {
   return response.json();
 };
 
+export const usePatchCompletedList = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, completed }: { id: number; completed: boolean }) => updateTodoItem(id, { completed }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['todos'] });
+    },
+  });
+};
+
 export const useUpdateTodo = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: ({ id, title, description }: { id: number; title: string; description: string }) =>
-      updateTodo(id, title, description),
+      updateTodoItem(id, { title, description }),
     onSuccess: (_, variables) => {
       const { id } = variables;
       queryClient.invalidateQueries({ queryKey: ['todos'] });

--- a/queries/todos/mutation.ts
+++ b/queries/todos/mutation.ts
@@ -23,3 +23,33 @@ export const usePatchCompletedList = () => {
     },
   });
 };
+
+const updateTodo = async (id: number, title: string, description: string) => {
+  const response = await fetch(`/api/todos/${id}`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ title, description }),
+  });
+
+  if (!response.ok) {
+    throw new Error();
+  }
+
+  return response.json();
+};
+
+export const useUpdateTodo = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, title, description }: { id: number; title: string; description: string }) =>
+      updateTodo(id, title, description),
+    onSuccess: (_, variables) => {
+      const { id } = variables;
+      queryClient.invalidateQueries({ queryKey: ['todos'] });
+      queryClient.invalidateQueries({ queryKey: ['todo', id] });
+    },
+  });
+};

--- a/queries/todos/queries.ts
+++ b/queries/todos/queries.ts
@@ -13,3 +13,30 @@ export const useGetAllList = () => {
     queryFn: () => getTodos(),
   });
 };
+
+export const getTodoDetail = async (id: number | null) => {
+  if (id === null) {
+    return null;
+  }
+
+  const response = await fetch(`/api/todos/${id}`);
+
+  if (!response.ok) {
+    throw new Error('할 일을 조회하는데 실패했습니다.');
+  }
+
+  const data = await response.json();
+
+  // 콘솔값 출력
+  console.log(data.todo);
+
+  return data.todo || null;
+};
+
+export const useGetTodoDetail = (id: number | null) => {
+  return useQuery({
+    queryKey: ['todos', 'detail', id],
+    queryFn: () => getTodoDetail(id),
+    enabled: id !== null && id !== undefined,
+  });
+};

--- a/queries/todos/queries.ts
+++ b/queries/todos/queries.ts
@@ -7,6 +7,7 @@ const getTodos = async () => {
   return data.todos;
 };
 
+// 상세 조회
 export const useGetAllList = () => {
   return useQuery({
     queryKey: ['todos'],

--- a/queries/todos/queries.ts
+++ b/queries/todos/queries.ts
@@ -7,7 +7,6 @@ const getTodos = async () => {
   return data.todos;
 };
 
-// 상세 조회
 export const useGetAllList = () => {
   return useQuery({
     queryKey: ['todos'],
@@ -15,7 +14,8 @@ export const useGetAllList = () => {
   });
 };
 
-export const getTodoDetail = async (id: number | null) => {
+// 상세 조회
+const getTodoDetail = async (id: number | null) => {
   if (id === null) {
     return null;
   }
@@ -36,7 +36,7 @@ export const getTodoDetail = async (id: number | null) => {
 
 export const useGetTodoDetail = (id: number | null) => {
   return useQuery({
-    queryKey: ['todos', 'detail', id],
+    queryKey: ['todo', id],
     queryFn: () => getTodoDetail(id),
     enabled: id !== null && id !== undefined,
   });


### PR DESCRIPTION
## 🔎 작업 내용

- getAllList 에서 상세 조회 및 수정을 구현하였습니다.
- conflict를 막기 위해 getAllList의 사본을 todos/detail에 생성하여 구현하였습니다.
- 상세 조회, 수정은 Dialog로 모달을 띄워서 구현하였습니다.
- 상세 조회, 수정 API 통신은 fetch로 구현하였습니다.
- 기존의 completed API가 title, description의 수정 API와 흡사하여 `제네릭`으로 묶어 구현하였습니다.
- 제목이 빈 값으로 request 되는 것을 방지하기 위해 Client 쪽에서 `제목 빈 값 에러 처리`를 구현하였습니다.

## 테스트 or 코드 구현 부분

- 제네릭으로 구현된 updateTodoItem 확인 부탁드립니다. 
